### PR TITLE
Fix an infinite loop in conDepth

### DIFF
--- a/Language/Haskell/Homplexity/TypeComplexity.hs
+++ b/Language/Haskell/Homplexity/TypeComplexity.hs
@@ -39,7 +39,7 @@ instance Metric ConDepth TypeSignature where
 
 -- | Function computing constructor depth of a @Type@.
 conDepth :: Type -> Int
-conDepth con = deeper con + maxOf conDepth (childrenBi con)
+conDepth con = deeper con + maxOf conDepth (filter (/= con) $ childrenBi con)
 
 -- | Check whether given constructor of @Type@ counts in constructor depth computation.
 deeper :: Type -> Int


### PR DESCRIPTION
I hoped it's going to be some fun optimization job, but it was just an infinite loop due to a quirk (?) in Biplate.
