### PR TITLE
Issue #9: update LTS and add new dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_cache:
 - echo $TRAVIS_HASKELL_VERSION
 language: haskell
 ghc:
+  - 8.8.1
   - 8.6.2
   - 8.4.4
   - 8.2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_cache:
 language: haskell
 ghc:
   - 8.8.1
-  - 8.6.2
+  - 8.6.3
   - 8.4.4
   - 8.2.2
   - 8.0.2

--- a/homplexity.cabal
+++ b/homplexity.cabal
@@ -79,7 +79,7 @@ Library
 executable homplexity-cli
   main-is:             Homplexity.hs
   hs-source-dirs:      app/
-  build-depends:       base             >=4.5  && <4.13,
+  build-depends:       base             >=4.5  && <4.14,
                        haskell-src-exts >=1.18 && <1.21,
                        directory        >=1.1  && <1.4,
                        filepath         >=1.2  && <1.5,
@@ -101,7 +101,7 @@ test-suite Comments
                     Language.Haskell.Homplexity.Comments
                     Language.Haskell.Homplexity.SrcSlice
   type:             exitcode-stdio-1.0
-  build-depends:    base             >=4.5  && <4.13,
+  build-depends:    base             >=4.5  && <4.14,
                     haskell-src-exts >=1.18 && <1.21,
                     uniplate         >=1.4  && <1.7
   default-language: Haskell2010

--- a/homplexity.cabal
+++ b/homplexity.cabal
@@ -11,7 +11,7 @@ description:         Homplexity aims to measure code complexity,
                      .
                        * too few comments
 
-homepage:            https://github.com/mgajda/homplexity
+-- homepage:            https://github.com/mgajda/homplexity
 license:             BSD3
 license-file:        LICENSE
 author:              Michal J. Gajda
@@ -49,7 +49,7 @@ Library
   Other-Modules:
     Paths_homplexity
   build-depends:       base             >=4.5  && <4.14,
-                       haskell-src-exts >=1.18 && <1.21,
+                       haskell-src-exts >=1.18 && <1.22,
                        directory        >=1.1  && <1.4,
                        filepath         >=1.2  && <1.5,
                        hflags           >=0.3  && <0.5,
@@ -70,7 +70,6 @@ Library
                        StandaloneDeriving,
                        ScopedTypeVariables,
                        TemplateHaskell,
-                       ViewPatterns,
                        BangPatterns,
                        GeneralizedNewtypeDeriving,
                        TypeFamilies
@@ -80,7 +79,7 @@ executable homplexity-cli
   main-is:             Homplexity.hs
   hs-source-dirs:      app/
   build-depends:       base             >=4.5  && <4.14,
-                       haskell-src-exts >=1.18 && <1.21,
+                       haskell-src-exts >=1.18 && <1.22,
                        directory        >=1.1  && <1.4,
                        filepath         >=1.2  && <1.5,
                        hflags           >=0.3  && <0.5,
@@ -102,7 +101,7 @@ test-suite Comments
                     Language.Haskell.Homplexity.SrcSlice
   type:             exitcode-stdio-1.0
   build-depends:    base             >=4.5  && <4.14,
-                    haskell-src-exts >=1.18 && <1.21,
+                    haskell-src-exts >=1.18 && <1.22,
                     uniplate         >=1.4  && <1.7
   default-language: Haskell2010
 

--- a/homplexity.cabal
+++ b/homplexity.cabal
@@ -48,7 +48,7 @@ Library
   build-tools:         happy            >= 1.19.0
   Other-Modules:
     Paths_homplexity
-  build-depends:       base             >=4.5  && <4.13,
+  build-depends:       base             >=4.5  && <4.14,
                        haskell-src-exts >=1.18 && <1.21,
                        directory        >=1.1  && <1.4,
                        filepath         >=1.2  && <1.5,

--- a/homplexity.cabal
+++ b/homplexity.cabal
@@ -11,7 +11,7 @@ description:         Homplexity aims to measure code complexity,
                      .
                        * too few comments
 
--- homepage:            https://github.com/mgajda/homplexity
+homepage:            https://github.com/mgajda/homplexity
 license:             BSD3
 license-file:        LICENSE
 author:              Michal J. Gajda

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,5 +3,4 @@ packages:
 - .
 extra-deps:
   - hflags-0.4.3@sha256:f6b85fc7cbd170787f49225646e62d5589e5dd75abe6f26d16287e5fff3e678e
-  - haskell-src-exts-1.20.3@sha256:83ae523bbec907a42c043de1f5bbf4c1554e7c3b898af07bb1ce6e80eaa282ec
 ld-options: -static

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,7 @@
-resolver: lts-9.21
+resolver: lts-14.4
 packages:
 - .
 extra-deps:
   - hflags-0.4.3@sha256:f6b85fc7cbd170787f49225646e62d5589e5dd75abe6f26d16287e5fff3e678e
+  - haskell-src-exts-1.20.3@sha256:83ae523bbec907a42c043de1f5bbf4c1554e7c3b898af07bb1ce6e80eaa282ec
 ld-options: -static


### PR DESCRIPTION
I've just update LTS and add strict version of `haskell-src-exts`.

`stack install homplexity` and `stack tests` works, `~/.local/bin/homplexity-cli` works too (I just run `~/.local/bin/homplexity-cli --help` and it outputs help message).

closes #9 