### PR TITLE
Adds version option to the CLI

### DIFF
--- a/app/Homplexity.hs
+++ b/app/Homplexity.hs
@@ -31,7 +31,12 @@ import System.IO
 
 import HFlags
 
+import Paths_homplexity (version)
+import Data.Version (showVersion)
+
 -- * Command line flag
+defineFlag "v:version" True "Show version"
+
 defineFlag "severity" Warning (concat ["level of output verbosity (", severityOptions, ")"])
 
 -- | Report to standard error output.
@@ -103,6 +108,8 @@ defineFlag "fakeFlag" Info "this flag is fake"
 main :: IO ()
 main = do
   args <- $initHFlags "Homplexity - automatic analysis of Haskell code quality"
+  flags_version <- putStrLn $ unwords ["Version: ", (showVersion version)]
+
   if null args
     then do report ("Use Haskell source file or directory as an argument, " ++
                     "or use --help to discover options.")

--- a/homplexity.cabal
+++ b/homplexity.cabal
@@ -49,6 +49,8 @@ Library
   build-tools:         happy            >= 1.19.0
   Other-Modules:
     Paths_homplexity
+  autogen-modules:
+    Paths_homplexity
   build-depends:       base             >=4.5  && <4.14,
                        bytestring,
                        containers       >=0.3  && <0.7,
@@ -84,6 +86,10 @@ Library
 executable homplexity-cli
   main-is:             Homplexity.hs
   hs-source-dirs:      app/
+  Other-Modules:
+    Paths_homplexity
+  autogen-modules:
+    Paths_homplexity
   build-depends:       base             >=4.5  && <4.14,
                        haskell-src-exts >=1.18 && <1.22,
                        directory        >=1.1  && <1.4,


### PR DESCRIPTION
```
~/c/homplexity(add-version-option|✚2)> homplexity-cli -v
Version:  0.4.4.3
Use Haskell source file or directory as an argument, or use --help to
discover options.
~/c/homplexity(add-version-option|✚2)>

```

Not ideal behavior, but perhaps a place to build from?

Will possibly resolve https://github.com/migamake/homplexity/issues/19

