### PR TITLE
Type class complexity measurement

### DIFF
--- a/homplexity.cabal
+++ b/homplexity.cabal
@@ -60,7 +60,7 @@ Library
                        deepseq          >=1.3  && <1.7,
                        directory        >=1.1  && <1.4,
                        filepath         >=1.2  && <1.5,
-                       haskell-src-exts >=1.18 && <1.22,
+                       haskell-src-exts >=1.21 && <1.22,
                        hflags           >=0.3  && <0.5,
                        template-haskell >=2.6  && <2.16,
                        uniplate         >=1.4  && <1.7

--- a/homplexity.cabal
+++ b/homplexity.cabal
@@ -45,6 +45,7 @@ Library
     Language.Haskell.Homplexity.Parse
     Language.Haskell.Homplexity.RecordFieldsCount
     Language.Haskell.Homplexity.SrcSlice
+    Language.Haskell.Homplexity.TypeClassComplexity
     Language.Haskell.Homplexity.TypeComplexity
     Language.Haskell.Homplexity.Utilities
   Hs-source-dirs:      lib

--- a/homplexity.cabal
+++ b/homplexity.cabal
@@ -113,6 +113,8 @@ test-suite homplexity-tests
   main-is:             Tests.hs
   hs-source-dirs:      tests
   other-modules:
+    Test.Utilities
+    Test.Metrics.TypeClassComplexitySpec
     Test.Parse.CommentsSpec
     Test.Parse.ExtensionsSpec
   type:                exitcode-stdio-1.0

--- a/lib/Language/Haskell/Homplexity/Assessment.hs
+++ b/lib/Language/Haskell/Homplexity/Assessment.hs
@@ -167,8 +167,8 @@ assessRecordFieldsCount (fromIntegral -> cy)
 
 -- ** Type class complexity
 -- *** Method count of type class
-defineFlag "typeClassNonTypeDeclWarning"  (7::Int) "issue warning when the number of methods in a type class exceeds this number"
-defineFlag "typeClassNonTypeDeclCritical" (9::Int) "issue critical when the number of methods in a type class exceeds this number"
+defineFlag "typeClassNonTypeDeclWarning"  (5::Int) "issue warning when the number of methods in a type class exceeds this number"
+defineFlag "typeClassNonTypeDeclCritical" (7::Int) "issue critical when the number of methods in a type class exceeds this number"
 
 assessTCNonTypeDeclCount :: Assessment NonTypeDeclCount
 assessTCNonTypeDeclCount (fromIntegral -> mc)

--- a/lib/Language/Haskell/Homplexity/Assessment.hs
+++ b/lib/Language/Haskell/Homplexity/Assessment.hs
@@ -22,6 +22,7 @@ import Language.Haskell.Homplexity.Cyclomatic
 import Language.Haskell.Homplexity.Message
 import Language.Haskell.Homplexity.Metric
 import Language.Haskell.Homplexity.RecordFieldsCount
+import Language.Haskell.Homplexity.TypeClassComplexity
 import Language.Haskell.Homplexity.TypeComplexity
 
 import HFlags
@@ -164,14 +165,42 @@ assessRecordFieldsCount (fromIntegral -> cy)
                         | cy > flags_recordFieldsCountWarning  = (Warning,  "should be less than " ++ show flags_recordFieldsCountWarning)
                         | otherwise                            = (Info,     ""                                                           )
 
+-- ** Type class complexity
+-- *** Method count of type class
+defineFlag "typeClassNonTypeDeclWarning"  (7::Int) "issue warning when the number of methods in a type class exceeds this number"
+defineFlag "typeClassNonTypeDeclCritical" (9::Int) "issue critical when the number of methods in a type class exceeds this number"
+
+assessTCNonTypeDeclCount :: Assessment NonTypeDeclCount
+assessTCNonTypeDeclCount (fromIntegral -> mc)
+  | mc > flags_typeClassNonTypeDeclCritical = (Critical, "should never have more than " ++
+                                              show flags_typeClassNonTypeDeclCritical)
+  | mc > flags_typeClassNonTypeDeclWarning  = (Warning,  " should have no more than " ++
+                                              show flags_typeClassNonTypeDeclWarning)
+  | otherwise = (Info, "")
+
+-- *** Associated type count of type class
+defineFlag "typeClassAssocTypesWarning"  (3::Int) "issue warning when the number of associated types in a type class exceeds this number"
+defineFlag "typeClassAssocTypesCritical" (5::Int) "issue critical when the number of associated types in a type class exceeds this number"
+
+assessTCAssocTypesCount :: Assessment AssocTypeCount
+assessTCAssocTypesCount (fromIntegral -> atc)
+  | atc > flags_typeClassAssocTypesCritical = (Critical, "should never have more than " ++
+                                              show flags_typeClassAssocTypesCritical)
+  | atc > flags_typeClassAssocTypesWarning  = (Warning,  " should have no more than " ++
+                                              show flags_typeClassAssocTypesWarning)
+  | otherwise                               = (Info, "")
+
 -- * Computing and assessing @Metric@s for all @CodeFragment@.
 -- | Compute all metrics, and assign severity depending on configured thresholds.
 metrics :: [Program -> Log]
-metrics  = [measureTopOccurs assessModuleLength       locT        moduleT
-           ,measureTopOccurs assessFunctionLength     locT        functionT
-           ,measureTopOccurs assessFunctionDepth      depthT      functionT
-           ,measureTopOccurs assessFunctionCC         cyclomaticT functionT
-           ,measureTopOccurs assessTypeConDepth       conDepthT   typeSignatureT
-           ,measureTopOccurs assessNumFunArgs         numFunArgsT typeSignatureT
-           ,measureTopOccurs assessRecordFieldsCount  recordFieldsCountT dataDefT]
+metrics  = [ measureTopOccurs assessModuleLength       locT               moduleT
+           , measureTopOccurs assessFunctionLength     locT               functionT
+           , measureTopOccurs assessFunctionDepth      depthT             functionT
+           , measureTopOccurs assessFunctionCC         cyclomaticT        functionT
+           , measureTopOccurs assessTypeConDepth       conDepthT          typeSignatureT
+           , measureTopOccurs assessNumFunArgs         numFunArgsT        typeSignatureT
+           , measureTopOccurs assessRecordFieldsCount  recordFieldsCountT dataDefT
+           , measureTopOccurs assessTCNonTypeDeclCount nonTypeDeclCountT  typeClassT
+           , measureTopOccurs assessTCAssocTypesCount  assocTypeCountT    typeClassT
+           ]
 

--- a/lib/Language/Haskell/Homplexity/CodeFragment.hs
+++ b/lib/Language/Haskell/Homplexity/CodeFragment.hs
@@ -178,10 +178,10 @@ instance CodeFragment Program where
 
 instance CodeFragment (Module SrcLoc) where
   type AST (Module SrcLoc)= Module SrcLoc
-  matchAST = Just 
-  fragmentName (Module _ (Just (ModuleHead _ (ModuleName _ theName) _ _)) _ _ _) = 
+  matchAST = Just
+  fragmentName (Module _ (Just (ModuleHead _ (ModuleName _ theName) _ _)) _ _ _) =
                 "module " ++ theName
-  fragmentName (Module _  Nothing                                         _ _ _) = 
+  fragmentName (Module _  Nothing                                         _ _ _) =
                 "<unnamed module>"
   fragmentName (XmlPage   _ (ModuleName _ theName) _ _ _ _ _)            = "XML page " ++ theName
   fragmentName (XmlHybrid _ (Just (ModuleHead _ (ModuleName _ theName) _ _))
@@ -202,5 +202,5 @@ instance CodeFragment TypeSignature where
 -- | Unpack @Name@ identifier into a @String@.
 unName :: Name a -> String
 unName (Symbol _ s) = s
-unName (Ident  _ i) = i 
+unName (Ident  _ i) = i
 

--- a/lib/Language/Haskell/Homplexity/Message.hs
+++ b/lib/Language/Haskell/Homplexity/Message.hs
@@ -64,7 +64,7 @@ instance Show Message where
                                                   . shows loc
                                                   -- . shows srcLine
                                                   -- . shows srcColumn
-                                                  . (':':)
+                                                  . (": "++)
                                                   . (msgText++)
                                                   . ('\n':)
 
@@ -95,7 +95,7 @@ instance FlagType Severity where
 message ::  Severity -> SrcLoc -> String -> Log
 message msgSeverity msgSrc msgText = Log $ Seq.singleton Message {..}
 
--- | TODO: automatic inference of the srcLine 
+-- | TODO: automatic inference of the srcLine
 -- | Log a certain error
 critical :: SrcLoc -> String -> Log
 critical  = message Critical

--- a/lib/Language/Haskell/Homplexity/RecordFieldsCount.hs
+++ b/lib/Language/Haskell/Homplexity/RecordFieldsCount.hs
@@ -37,7 +37,7 @@ measureCons = sumOf (\(QualConDecl _ _ _ decl) -> count decl)
 measureGadts :: [GadtDecl SrcLoc] -> Int
 measureGadts = sumOf count
   where
-    count (GadtDecl _ _ maybeFields _) = maybe 0 length maybeFields
+    count (GadtDecl _ _ _ _ maybeFields _) = maybe 0 length maybeFields
 
 instance Show RecordFieldsCount where
   showsPrec _ (RecordFieldsCount rfc) = ("record fields count of " ++)

--- a/lib/Language/Haskell/Homplexity/TypeClassComplexity.hs
+++ b/lib/Language/Haskell/Homplexity/TypeClassComplexity.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+-- | Measuring the complexity of type class declarations
+module Language.Haskell.Homplexity.TypeClassComplexity
+  ( NonTypeDeclCount
+  , nonTypeDeclCountT
+  , AssocTypeCount
+  , assocTypeCountT
+  ) where
+
+import Data.Data
+import Data.Maybe
+import Data.Generics.Uniplate.Data
+import Language.Haskell.Exts.SrcLoc
+import Language.Haskell.Exts.Syntax
+import Language.Haskell.Homplexity.CodeFragment
+import Language.Haskell.Homplexity.Metric
+import Language.Haskell.Homplexity.Utilities
+
+-- NOTE: It is non-trivial to decide whether a class declaration
+-- is a method or a value. To correctly do that, we would have to
+-- see through type synonyms. So, we will aggregate methods and values.
+
+-- * Type class method count
+-- | Represents the number of methods and value in a type class.
+newtype NonTypeDeclCount = NonTypeDeclCount { unNonTypeDeclCount :: Int }
+  deriving (Eq, Ord, Enum, Num, Real, Integral)
+
+-- | For passing @NonTypeDeclCount@ type as parameter.
+nonTypeDeclCountT :: Proxy NonTypeDeclCount
+nonTypeDeclCountT  = Proxy
+
+instance Show NonTypeDeclCount where
+  showsPrec _ (NonTypeDeclCount mc) = ("method + value count of " ++)
+                                    . shows mc
+
+instance Metric NonTypeDeclCount TypeClass where
+  measure x = NonTypeDeclCount . sumOf method . fromMaybe [] . tcDecls $ x where
+
+    method :: ClassDecl l -> Int
+    method (ClsDecl _ TypeSig{}) = 1
+    method _                     = 0
+
+-- * Type class associated types count
+-- | Represents the number of associated types in a type class.
+-- It includes both associated type and data families.
+newtype AssocTypeCount = AssocTypeCount { unAssocTypeCount :: Int }
+  deriving (Eq, Ord, Enum, Num, Real, Integral)
+
+-- | For passing @AssocTypeCount@ type as parameter.
+assocTypeCountT :: Proxy AssocTypeCount
+assocTypeCountT  = Proxy
+
+instance Show AssocTypeCount where
+  showsPrec _ (AssocTypeCount atc) = ("associated type count of " ++)
+                                   . shows atc
+
+instance Metric AssocTypeCount TypeClass where
+  measure x = AssocTypeCount . sumOf assocType . fromMaybe [] . tcDecls $ x where
+
+    assocType :: ClassDecl l -> Int
+    assocType ClsTyFam{}   = 1
+    assocType ClsTyDef{}   = 1
+    assocType ClsDataFam{} = 1
+    assocType _            = 0
+

--- a/lib/Language/Haskell/Homplexity/Utilities.hs
+++ b/lib/Language/Haskell/Homplexity/Utilities.hs
@@ -1,7 +1,10 @@
 module Language.Haskell.Homplexity.Utilities(
     sumOf
   , maxOf
+  , declHeadName
   ) where
+
+import Language.Haskell.Exts.Syntax (DeclHead(..), Name)
 
 -- | Maximum of the results of mapping the function over the list.
 maxOf :: (a -> Int) -> [a] -> Int
@@ -10,3 +13,10 @@ maxOf f = maximum . (0:). map f
 -- | Sum the results of mapping the function over the list.
 sumOf :: (a -> Int) -> [a] -> Int
 sumOf f = sum . map f
+
+-- | Get the name of a declaration.
+declHeadName :: DeclHead l -> Name l
+declHeadName (DHead _ name)     = name
+declHeadName (DHInfix _ _ name) = name
+declHeadName (DHParen _ dh)     = declHeadName dh
+declHeadName (DHApp _ dh _)     = declHeadName dh

--- a/tests/Test/Metrics/TypeClassComplexitySpec.hs
+++ b/tests/Test/Metrics/TypeClassComplexitySpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeApplications #-}
 module Test.Metrics.TypeClassComplexitySpec where
 
 
@@ -6,25 +7,16 @@ import Test.Utilities
 
 import Language.Haskell.Exts.Extension
 import Language.Haskell.Homplexity.TypeClassComplexity
-import Language.Haskell.Homplexity.CodeFragment (TypeClass, occurs)
-import Language.Haskell.Homplexity.Metric (measure)
-import Language.Haskell.Homplexity.Parse (parseSource)
+import Language.Haskell.Homplexity.CodeFragment (TypeClass)
 
 spec :: Spec
 spec = describe "tests for type class complexity" $ do
   it "correctly counts methods and values" $ flip shouldReturn (5 :: NonTypeDeclCount) $ do
-    result <- parseSource [] (testFile "TypeClassComplexityTest.hs")
-    p <- case result of
-      Left  logs      -> error $ show logs
-      Right (prog, _) -> pure prog
-    let tyClassDecls = occurs p :: [TypeClass]
-    pure $ sum $ map measure tyClassDecls
+    measureSumOnFile @NonTypeDeclCount @TypeClass
+      [] (testFile "TypeClassComplexityTest.hs")
 
   it "correctly counts associated types" $ flip shouldReturn (5 :: AssocTypeCount) $ do
-    result <- parseSource [EnableExtension TypeFamilies] (testFile "TypeClassComplexityTest.hs")
-    p <- case result of
-      Left  logs      -> error $ show logs
-      Right (prog, _) -> pure prog
-    let tyClassDecls = occurs p :: [TypeClass]
-    pure $ sum $ map measure tyClassDecls
+    measureSumOnFile @AssocTypeCount @TypeClass
+      [EnableExtension TypeFamilies] (testFile "TypeClassComplexityTest.hs")
+
 

--- a/tests/Test/Metrics/TypeClassComplexitySpec.hs
+++ b/tests/Test/Metrics/TypeClassComplexitySpec.hs
@@ -1,0 +1,30 @@
+module Test.Metrics.TypeClassComplexitySpec where
+
+
+import Test.Hspec
+import Test.Utilities
+
+import Language.Haskell.Exts.Extension
+import Language.Haskell.Homplexity.TypeClassComplexity
+import Language.Haskell.Homplexity.CodeFragment (TypeClass, occurs)
+import Language.Haskell.Homplexity.Metric (measure)
+import Language.Haskell.Homplexity.Parse (parseSource)
+
+spec :: Spec
+spec = describe "tests for type class complexity" $ do
+  it "correctly counts methods and values" $ flip shouldReturn (5 :: NonTypeDeclCount) $ do
+    result <- parseSource [] (testFile "TypeClassComplexityTest.hs")
+    p <- case result of
+      Left  logs      -> error $ show logs
+      Right (prog, _) -> pure prog
+    let tyClassDecls = occurs p :: [TypeClass]
+    pure $ sum $ map measure tyClassDecls
+
+  it "correctly counts associated types" $ flip shouldReturn (5 :: AssocTypeCount) $ do
+    result <- parseSource [EnableExtension TypeFamilies] (testFile "TypeClassComplexityTest.hs")
+    p <- case result of
+      Left  logs      -> error $ show logs
+      Right (prog, _) -> pure prog
+    let tyClassDecls = occurs p :: [TypeClass]
+    pure $ sum $ map measure tyClassDecls
+

--- a/tests/Test/Parse/ExtensionsSpec.hs
+++ b/tests/Test/Parse/ExtensionsSpec.hs
@@ -1,18 +1,13 @@
 module Test.Parse.ExtensionsSpec where
 
 
-import System.FilePath
 import Language.Haskell.Exts.Extension
 
 import Test.Hspec
+import Test.Utilities
 
 import Language.Haskell.Homplexity.Parse
 import Language.Haskell.Homplexity.CabalFiles
-
-
--- | Constructs OS-independent path to test file
-testFile :: FilePath -> FilePath
-testFile fn = "tests" </> "test-data" </> fn
 
 
 spec :: Spec

--- a/tests/Test/Utilities.hs
+++ b/tests/Test/Utilities.hs
@@ -1,0 +1,9 @@
+module Test.Utilities
+  ( testFile
+  ) where
+
+import System.FilePath
+
+-- | Constructs OS-independent path to test file
+testFile :: FilePath -> FilePath
+testFile fn = "tests" </> "test-data" </> fn

--- a/tests/Test/Utilities.hs
+++ b/tests/Test/Utilities.hs
@@ -1,9 +1,26 @@
+{-# LANGUAGE AllowAmbiguousTypes, ScopedTypeVariables #-}
 module Test.Utilities
   ( testFile
+  , measureSumOnFile
   ) where
 
-import System.FilePath
+import System.FilePath (FilePath, (</>))
+
+import Language.Haskell.Exts (Extension)
+import Language.Haskell.Homplexity.CodeFragment (occurs)
+import Language.Haskell.Homplexity.Metric (Metric(..))
+import Language.Haskell.Homplexity.Parse (parseSource)
 
 -- | Constructs OS-independent path to test file
 testFile :: FilePath -> FilePath
 testFile fn = "tests" </> "test-data" </> fn
+
+
+measureSumOnFile :: forall m c. (Metric m c, Num m) => [Extension] -> FilePath -> IO m
+measureSumOnFile exts path = do
+  result <- parseSource exts path
+  p <- case result of
+    Left  logs      -> error $ show logs
+    Right (prog, _) -> pure prog
+  let codeFrags = occurs p :: [c]
+  pure $ sum $ map measure codeFrags

--- a/tests/test-data/TypeClassComplexityTest.hs
+++ b/tests/test-data/TypeClassComplexityTest.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE TypeFamilies, DefaultSignatures #-}
+module TypeClassComplexityTest where
+
+class C a where
+  type T1             -- counts as type
+  type T2             -- counts as type
+  type T3             -- counts as type
+
+  type T4 = Int       -- counts as type
+
+  data T5             -- counts as type
+
+  f1 :: a -> Int      -- counts as non-type decl
+  f2 :: a -> Int      -- counts as non-type decl
+  f3 :: a -> Int      -- counts as non-type decl
+
+  f4 :: a -> Int      -- counts as non-type decl
+  f4 _ = 0
+
+  x :: Maybe (a -> a) -- counts as non-type decl
+  x = Nothing
+
+


### PR DESCRIPTION
Added metrics for measuring type class complexity as per #15. 

Now the analyses measure the number of associated types (both type families and data families) and non-type declarations. By non-type declaration, I mean methods and values. These two are aggregated because it would be non-trivial to decide whether a class declaration is a method or a value. For that, we would have to see through type synonyms.