### PR TITLE
Add optional html output

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Patches and suggestions are welcome.
 
 You may run `homplexity --help` to see options.
 
+For html output, run:
+```
+    homplexity --format=HTML Main.hs src/ 
+```
+
+
 How does it work?
 -----------------
 

--- a/homplexity.cabal
+++ b/homplexity.cabal
@@ -29,6 +29,10 @@ tested-with:         GHC==7.8.4
                    , GHC==8.4.4
                    , GHC==8.6.2
 
+Flag Html
+  Description: Enable HTML output via blaze-html
+  Default:     True
+
 source-repository head
   type:     git
   location: https://github.com/mgajda/homplexity.git
@@ -84,6 +88,10 @@ Library
                        GeneralizedNewtypeDeriving,
                        TypeFamilies
   default-language:    Haskell2010
+  if flag(Html)
+    CPP-Options:       -DHTML_OUTPUT
+    build-depends:     blaze-html   >= 0.9 && < 1,
+                       blaze-markup >= 0.8 && < 0.9
 
 executable homplexity-cli
   main-is:             Homplexity.hs
@@ -106,6 +114,10 @@ executable homplexity-cli
   default-language:    Haskell2010
   -- STATIC: ld-options: -static
   -- STATIC: ghc-options: -fPIC
+  if flag(Html)
+    CPP-Options:       -DHTML_OUTPUT
+    build-depends:     blaze-html   >= 0.9  && < 1,
+                       bytestring   >= 0.10 && < 0.11
 
 
 test-suite homplexity-tests

--- a/lib/Language/Haskell/Homplexity/Message.hs
+++ b/lib/Language/Haskell/Homplexity/Message.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE OverloadedStrings          #-}
 -- | Classifying messages by severity and filtering them.
 module Language.Haskell.Homplexity.Message (
     Log
@@ -27,9 +28,15 @@ import Data.Monoid
 import Data.Semigroup
 #endif
 import Data.Sequence                            as Seq
-import Language.Haskell.Exts
+import Language.Haskell.Exts hiding (style)
 import Language.Haskell.TH.Syntax                           (Lift(..))
 import HFlags
+#ifdef HTML_OUTPUT
+import Prelude hiding (head, id, div, span)
+import Text.Blaze.Html4.Strict hiding (map, style)
+import Text.Blaze.Html4.Strict.Attributes hiding (title, span)
+import Text.Blaze.Renderer.Utf8 (renderMarkup)
+#endif
 
 -- | Keeps a set of messages
 newtype Log = Log { unLog :: Seq Message }
@@ -68,6 +75,33 @@ instance Show Message where
                                                   . (msgText++)
                                                   . ('\n':)
 
+#ifdef HTML_OUTPUT
+instance ToMarkup Message where
+  toMarkup Message {..} =
+    p ! classId $
+     (toMarkup msgSeverity
+       <> string ": "
+       <> toMarkup msgSrc
+       <> string ": "
+       <> string msgText)
+    where
+      classId = case msgSeverity of
+                     Debug    -> class_ "debug"
+                     Info     -> class_ "info"
+                     Warning  -> class_ "warning"
+                     Critical -> class_ "critical"
+
+instance ToMarkup Severity where
+  toMarkup Debug    = span   ! class_ "severity" $ string (show Debug)
+  toMarkup Info     = span   ! class_ "severity" $ string (show Info)
+  toMarkup Warning  = strong ! class_ "severity" $ string (show Warning)
+  toMarkup Critical = strong ! class_ "severity" $ string (show Critical)
+
+instance ToMarkup SrcLoc where
+  toMarkup SrcLoc {..} = a ! href (toValue srcFilename) $ (string srcFilename)
+
+#endif
+
 -- | Message severity
 data Severity = Debug
               | Info
@@ -95,7 +129,7 @@ instance FlagType Severity where
 message ::  Severity -> SrcLoc -> String -> Log
 message msgSeverity msgSrc msgText = Log $ Seq.singleton Message {..}
 
--- | TODO: automatic inference of the srcLine 
+-- | TODO: automatic inference of the srcLine
 -- | Log a certain error
 critical :: SrcLoc -> String -> Log
 critical  = message Critical


### PR DESCRIPTION
This feature can be disabled at compile time, since the
dependencies might be expensive.

The homplexity version and the diagnostic about parsed Modules
is sent to stderr now since it would mess up the html.

Fixes #23 